### PR TITLE
Add information about sampled contig

### DIFF
--- a/rfdiffusion/inference/model_runners.py
+++ b/rfdiffusion/inference/model_runners.py
@@ -237,7 +237,9 @@ class Sampler:
         Construct contig class describing the protein to be generated
         """
         self._log.info(f'Using contig: {self.contig_conf.contigs}')
-        return ContigMap(target_feats, **self.contig_conf)
+        contig_map = ContigMap(target_feats, **self.contig_conf)
+        self._log.info(f'Sampled contig: {contig_map.sampled_mask}')
+        return contig_map
 
     def construct_denoiser(self, L, visible):
         """Make length-specific denoiser."""


### PR DESCRIPTION
In addition to the general contig specification which is being used for the generation, it would also be helpful to monitor what the actual randomly sampled contig is. I believe this change does that:

```
[2024-04-26 13:29:13,350][rfdiffusion.inference.model_runners][INFO] - Using contig: ['10-100/A1083-1083/10-100/A1051-1051/10-100/A1180-1180/10-100']
[2024-04-26 13:29:13,351][rfdiffusion.inference.model_runners][INFO] - Sampled contig: ['53-53/A1083-1083/100-100/A1051-1051/86-86/A1180-1180/22-22']
```